### PR TITLE
Fixed error "key missing from dictionary" in Jira SDK

### DIFF
--- a/Atlassian.Jira/Atlassian.Jira.csproj
+++ b/Atlassian.Jira/Atlassian.Jira.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Apiiro.Atlassian.Jira</PackageId>
-    <Version>0.1.8</Version>
+    <Version>0.1.9</Version>
     <Authors>Federico Silva Armas</Authors>
     <Company>Federico Silva Armas</Company>
     <Product>Atlassian.SDK</Product>

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Please open an issue if you encounter a bug, have suggestions or feature request
 
 Federico Silva Armas
 [http://federicosilva.net](http://federicosilva.net/)
+

--- a/README.md
+++ b/README.md
@@ -71,4 +71,3 @@ Please open an issue if you encounter a bug, have suggestions or feature request
 
 Federico Silva Armas
 [http://federicosilva.net](http://federicosilva.net/)
-


### PR DESCRIPTION
Closes LIM-2457.
Caused by having over 100 linked issues to a single issue.
Tested it on a private JIRA project.