### PR TITLE
Handles potential missing archived issues

### DIFF
--- a/Atlassian.Jira/Atlassian.Jira.csproj
+++ b/Atlassian.Jira/Atlassian.Jira.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Apiiro.Atlassian.Jira</PackageId>
-    <Version>0.1.10</Version>
+    <Version>0.1.11</Version>
     <Authors>Federico Silva Armas</Authors>
     <Company>Federico Silva Armas</Company>
     <Product>Atlassian.SDK</Product>


### PR DESCRIPTION
Relates to LIM-2457.

Archived issues exist, but cannot be searched.
This means they're in the issue links, but not found as issue objects in the dictionary.
This change (hopefully) handles that case.
Could not test it due to our Jiras not being premium Jiras that allow archiving projects.