### PR TITLE
Unify GetIssueTypes and GetComponents

### DIFF
--- a/Atlassian.Jira/Atlassian.Jira.csproj
+++ b/Atlassian.Jira/Atlassian.Jira.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Apiiro.Atlassian.Jira</PackageId>
-    <Version>0.1.22</Version>
+    <Version>0.1.23</Version>
     <Authors>Federico Silva Armas</Authors>
     <Company>Federico Silva Armas</Company>
     <Product>Atlassian.SDK</Product>

--- a/Atlassian.Jira/IIssueTypeService.cs
+++ b/Atlassian.Jira/IIssueTypeService.cs
@@ -15,11 +15,5 @@ namespace Atlassian.Jira
         /// Returns all the issue types within JIRA.
         /// </summary>
         Task<IEnumerable<IssueType>> GetIssueTypesAsync(CancellationToken token = default(CancellationToken));
-
-        /// <summary>
-        /// Returns the issue types within JIRA for the project specified.
-        /// </summary>
-        Task<IEnumerable<IssueType>> GetIssueTypesForProjectAsync(string projectKey, CancellationToken token = default(CancellationToken));
-
     }
 }

--- a/Atlassian.Jira/IProjectService.cs
+++ b/Atlassian.Jira/IProjectService.cs
@@ -25,6 +25,8 @@ namespace Atlassian.Jira
         /// <summary>
         /// Returns the issue types and components within JIRA for the project specified.
         /// </summary>
-        Task<(IEnumerable<IssueType>, IEnumerable<ProjectComponent>)> GetProjectIssueTypesAndComponentsAsync(string projectKey, CancellationToken token = default(CancellationToken));
+        Task<(IEnumerable<IssueType> IssueTypes, IEnumerable<ProjectComponent> Components)>
+            GetProjectIssueTypesAndComponentsAsync(string projectKey,
+                CancellationToken token = default(CancellationToken));
     }
 }

--- a/Atlassian.Jira/IProjectService.cs
+++ b/Atlassian.Jira/IProjectService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,5 +21,10 @@ namespace Atlassian.Jira
         /// <param name="projectKey">Project key for the single project to load</param>
         /// <param name="token">Cancellation token for this operation.</param>
         Task<Project> GetProjectAsync(string projectKey, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
+        /// Returns the issue types and components within JIRA for the project specified.
+        /// </summary>
+        Task<(IEnumerable<IssueType>, IEnumerable<ProjectComponent>)> GetProjectIssueTypesAndComponentsAsync(string projectKey, CancellationToken token = default(CancellationToken));
     }
 }

--- a/Atlassian.Jira/IssueType.cs
+++ b/Atlassian.Jira/IssueType.cs
@@ -54,7 +54,7 @@ namespace Atlassian.Jira
             {
                 // There are multiple issue types with the same name. Possibly because there are a combination
                 //  of classic and NextGen projects in Jira. Get the issue types from the project if it is defined.
-                results = await jira.IssueTypes.GetIssueTypesForProjectAsync(ProjectKey).ConfigureAwait(false);
+                results = (await jira.Projects.GetProjectIssueTypesAndComponentsAsync(ProjectKey, token).ConfigureAwait(false)).Item1;
             }
 
             return results as IEnumerable<JiraNamedEntity>;

--- a/Atlassian.Jira/IssueType.cs
+++ b/Atlassian.Jira/IssueType.cs
@@ -54,7 +54,7 @@ namespace Atlassian.Jira
             {
                 // There are multiple issue types with the same name. Possibly because there are a combination
                 //  of classic and NextGen projects in Jira. Get the issue types from the project if it is defined.
-                results = (await jira.Projects.GetProjectIssueTypesAndComponentsAsync(ProjectKey, token).ConfigureAwait(false)).Item1;
+                results = (await jira.Projects.GetProjectIssueTypesAndComponentsAsync(ProjectKey, token).ConfigureAwait(false)).IssueTypes;
             }
 
             return results as IEnumerable<JiraNamedEntity>;

--- a/Atlassian.Jira/Project.cs
+++ b/Atlassian.Jira/Project.cs
@@ -105,9 +105,9 @@ namespace Atlassian.Jira
         /// Gets the issue types for the current project.
         /// </summary>
         /// <param name="token">Cancellation token for this operation.</param>
-        public Task<IEnumerable<IssueType>> GetIssueTypesAsync(CancellationToken token = default(CancellationToken))
+        public async Task<IEnumerable<IssueType>> GetIssueTypesAsync(CancellationToken token = default(CancellationToken))
         {
-            return _jira.IssueTypes.GetIssueTypesForProjectAsync(Key, token);
+            return (await _jira.Projects.GetProjectIssueTypesAndComponentsAsync(Key, token)).Item1;
         }
 
         /// <summary>

--- a/Atlassian.Jira/Project.cs
+++ b/Atlassian.Jira/Project.cs
@@ -107,7 +107,7 @@ namespace Atlassian.Jira
         /// <param name="token">Cancellation token for this operation.</param>
         public async Task<IEnumerable<IssueType>> GetIssueTypesAsync(CancellationToken token = default(CancellationToken))
         {
-            return (await _jira.Projects.GetProjectIssueTypesAndComponentsAsync(Key, token)).Item1;
+            return (await _jira.Projects.GetProjectIssueTypesAndComponentsAsync(Key, token)).IssueTypes;
         }
 
         /// <summary>

--- a/Atlassian.Jira/Remote/IssueTypeService.cs
+++ b/Atlassian.Jira/Remote/IssueTypeService.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using RestSharp;
 
 namespace Atlassian.Jira.Remote
@@ -21,19 +19,6 @@ namespace Atlassian.Jira.Remote
         {
             var remoteIssueTypes = await _jira.RestClient.ExecuteRequestAsync<RemoteIssueType[]>(Method.GET, "rest/api/2/issuetype", null, token).ConfigureAwait(false);
             var issueTypes = remoteIssueTypes.Select(t => new IssueType(t));
-            return issueTypes;
-        }
-
-        public async Task<IEnumerable<IssueType>> GetIssueTypesForProjectAsync(string projectKey, CancellationToken token = default(CancellationToken))
-        {
-            var resource = String.Format("rest/api/2/project/{0}", projectKey);
-            var projectJson = await _jira.RestClient.ExecuteRequestAsync(Method.GET, resource, null, token).ConfigureAwait(false);
-            var serializerSettings = _jira.RestClient.Settings.JsonSerializerSettings;
-
-            var issueTypes = projectJson["issueTypes"]
-                .Select(issueTypeJson => JsonConvert.DeserializeObject<RemoteIssueType>(issueTypeJson.ToString(), serializerSettings))
-                .Select(remoteIssueType => new IssueType(remoteIssueType));
-
             return issueTypes;
         }
     }

--- a/Atlassian.Jira/Remote/ProjectService.cs
+++ b/Atlassian.Jira/Remote/ProjectService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace Atlassian.Jira.Remote
@@ -27,6 +28,24 @@ namespace Atlassian.Jira.Remote
             var resource = String.Format("rest/api/2/project/{0}?expand=lead,url", projectKey);
             var remoteProject = await _jira.RestClient.ExecuteRequestAsync<RemoteProject>(Method.GET, resource, null, token).ConfigureAwait(false);
             return new Project(_jira, remoteProject);
+        }
+
+        public async Task<(IEnumerable<IssueType>, IEnumerable<ProjectComponent>)>
+            GetProjectIssueTypesAndComponentsAsync(string projectKey, CancellationToken token = default)
+        {
+            var resource = String.Format("rest/api/2/project/{0}", projectKey);
+            var projectJson = await _jira.RestClient.ExecuteRequestAsync(Method.GET, resource, null, token).ConfigureAwait(false);
+            var serializerSettings = _jira.RestClient.Settings.JsonSerializerSettings;
+
+            var issueTypes = projectJson["issueTypes"]
+                .Select(issueTypeJson => JsonConvert.DeserializeObject<RemoteIssueType>(issueTypeJson.ToString(), serializerSettings))
+                .Select(remoteIssueType => new IssueType(remoteIssueType));
+
+            var components = projectJson["components"]
+                .Select(componentJson => JsonConvert.DeserializeObject<RemoteComponent>(componentJson.ToString(), serializerSettings))
+                .Select(remoteComponent => new ProjectComponent(remoteComponent));
+
+            return (issueTypes, components);
         }
     }
 }

--- a/Atlassian.Jira/Remote/ProjectService.cs
+++ b/Atlassian.Jira/Remote/ProjectService.cs
@@ -30,7 +30,7 @@ namespace Atlassian.Jira.Remote
             return new Project(_jira, remoteProject);
         }
 
-        public async Task<(IEnumerable<IssueType>, IEnumerable<ProjectComponent>)>
+        public async Task<(IEnumerable<IssueType> IssueTypes, IEnumerable<ProjectComponent> Components)>
             GetProjectIssueTypesAndComponentsAsync(string projectKey, CancellationToken token = default)
         {
             var resource = String.Format("rest/api/2/project/{0}", projectKey);


### PR DESCRIPTION
Apparently the call we make today to fetch issue types also returns components, modified the code to return both to the client, this will save us a call per project.

Tested on my velocity environment.