### PR TITLE
Add support for a bearer authenticated client

### DIFF
--- a/Atlassian.Jira/Atlassian.Jira.csproj
+++ b/Atlassian.Jira/Atlassian.Jira.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Apiiro.Atlassian.Jira</PackageId>
-    <Version>0.1.24</Version>
+    <Version>0.1.25</Version>
     <Authors>Federico Silva Armas</Authors>
     <Company>Federico Silva Armas</Company>
     <Product>Atlassian.SDK</Product>

--- a/Atlassian.Jira/Jira.cs
+++ b/Atlassian.Jira/Jira.cs
@@ -27,7 +27,7 @@ namespace Atlassian.Jira
         }
 
         /// <summary>
-        /// Creates a JIRA rest client.
+        /// Creates a JIRA rest client with Basic auth.
         /// </summary>
         /// <param name="url">Url to the JIRA server.</param>
         /// <param name="username">Username used to authenticate.</param>
@@ -38,6 +38,21 @@ namespace Atlassian.Jira
         {
             settings = settings ?? new JiraRestClientSettings();
             var restClient = new JiraRestClient(url, username, password, settings);
+
+            return CreateRestClient(restClient);
+        }
+
+        /// <summary>
+        /// Creates a JIRA rest client with Bearer auth.
+        /// </summary>
+        /// <param name="url">Url to the JIRA server.</param>
+        /// <param name="token">Token used to authenticate.</param>
+        /// <param name="settings">Settings to configure the rest client.</param>
+        /// <returns>Jira object configured to use REST API.</returns>
+        public static Jira CreateTokenRestClient(string url, string token, JiraRestClientSettings settings = null)
+        {
+            settings ??= new JiraRestClientSettings();
+            var restClient = new JiraRestClient(url, token, settings);
 
             return CreateRestClient(restClient);
         }

--- a/Atlassian.Jira/Remote/JiraRestClient.cs
+++ b/Atlassian.Jira/Remote/JiraRestClient.cs
@@ -25,7 +25,7 @@ namespace Atlassian.Jira.Remote
         private readonly JiraRestClientSettings _clientSettings;
 
         /// <summary>
-        /// Creates a new instance of the JiraRestClient class.
+        /// Creates a new instance of the JiraRestClient class for Basic auth.
         /// </summary>
         /// <param name="url">Url to the JIRA server.</param>
         /// <param name="username">Username used to authenticate.</param>
@@ -33,6 +33,17 @@ namespace Atlassian.Jira.Remote
         /// <param name="settings">Settings to configure the rest client.</param>
         public JiraRestClient(string url, string username = null, string password = null, JiraRestClientSettings settings = null)
             : this(url, new HttpBasicAuthenticator(username, password), settings)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the JiraRestClient class for Bearer auth.
+        /// </summary>
+        /// <param name="url">Url to the JIRA server.</param>
+        /// <param name="token">Token used to authenticate.</param>
+        /// <param name="settings">Settings to configure the rest client.</param>
+        public JiraRestClient(string url, string token, JiraRestClientSettings settings = null)
+            : this(url, new JwtAuthenticator(token), settings)
         {
         }
 


### PR DESCRIPTION
Jira Server v9 uses bearer token for PAT authentication (while Jira cloud uses basic auth for PAT authentication)