### PR TITLE
Include attachments in JQL query response

### DIFF
--- a/Atlassian.Jira/Atlassian.Jira.csproj
+++ b/Atlassian.Jira/Atlassian.Jira.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Apiiro.Atlassian.Jira</PackageId>
-    <Version>0.1.29</Version>
+    <Version>0.1.30</Version>
     <Authors>Federico Silva Armas</Authors>
     <Company>Federico Silva Armas</Company>
     <Product>Atlassian.SDK</Product>

--- a/Atlassian.Jira/Issue.cs
+++ b/Atlassian.Jira/Issue.cs
@@ -415,6 +415,19 @@ namespace Atlassian.Jira
         }
 
         /// <summary>
+        /// The attachments associated with this issue.
+        /// Note: Attachments are only populated if included in the JQL query fields.
+        /// </summary>
+        public IEnumerable<Attachment> Attachments
+        {
+            get
+            {
+                var remoteAttachments = _originalIssue.remoteAttachments ?? Array.Empty<RemoteAttachment>();
+                return remoteAttachments.Select(ra => new Attachment(_jira, ra));
+            }
+        }
+
+        /// <summary>
         /// The custom fields associated with this issue
         /// </summary>
         public CustomFieldValueCollection CustomFields

--- a/Atlassian.Jira/Remote/IssueService.cs
+++ b/Atlassian.Jira/Remote/IssueService.cs
@@ -21,7 +21,7 @@ namespace Atlassian.Jira.Remote
 
         private readonly Jira _jira;
         private readonly JiraRestClientSettings _restSettings;
-        private readonly string[] _excludedFields = new string[] { "comment", "attachment", "issuelinks", "subtasks", "watches", "worklog" };
+        private readonly string[] _excludedFields = new string[] { "comment", "issuelinks", "subtasks", "watches", "worklog" };
 
         private JsonSerializerSettings _serializerSettings;
 


### PR DESCRIPTION
Part of LIM-36635
Include attachments in JQL query response:
- Remove 'attachment' from excluded fields in IssueService.cs
- Add 'Attachments' property to Issue class to expose attachment data
- Bump version to 0.1.30

This allows retrieving attachment metadata (filename, size, mimeType, etc.) directly from JQL queries without making additional API calls per issue.