### PR TITLE
Handle missing 'issues' field in Jira Cloud search responses

### DIFF
--- a/Atlassian.Jira.Test/IssueServiceTest.cs
+++ b/Atlassian.Jira.Test/IssueServiceTest.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Atlassian.Jira.Remote;
+using Moq;
+using Newtonsoft.Json.Linq;
+using RestSharp;
+using Xunit;
+
+namespace Atlassian.Jira.Test
+{
+    public class IssueServiceTest
+    {
+        private static TestableJira CreateJiraWithSearchResponses(params string[] responses)
+        {
+            var jira = TestableJira.Create();
+            jira.RestService.Setup(c => c.Settings).Returns(new JiraRestClientSettings());
+            jira.IssueFieldService
+                .Setup(s => s.GetCustomFieldsAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Enumerable.Empty<CustomField>()));
+            jira.RestService
+                .Setup(c => c.ExecuteRequestAsync(Method.POST, "rest/api/3/search/jql", It.IsAny<object>(), It.IsAny<CancellationToken>()))
+                .ReturnsInOrder(responses.Select(response => (object)Task.FromResult(JToken.Parse(response))).ToArray());
+            return jira;
+        }
+
+        private static IssueService CreateIssueService(TestableJira jira)
+            => new IssueService(jira, new JiraRestClientSettings());
+
+        [Fact]
+        public async Task GetIssuesFromJqlAsync_IssuesFieldPresent_DoesNotRetry()
+        {
+            var jira = CreateJiraWithSearchResponses("{\"issues\":[],\"isLast\":true}");
+            var service = CreateIssueService(jira);
+
+            var result = await service.GetIssuesFromJqlAsync(new IssueSearchOptions("project = TST"), false);
+
+            Assert.Empty(result);
+            jira.RestService.Verify(
+                c => c.ExecuteRequestAsync(Method.POST, "rest/api/3/search/jql", It.IsAny<object>(), It.IsAny<CancellationToken>()),
+                Times.Once());
+        }
+
+        [Fact]
+        public async Task GetIssuesFromJqlAsync_IssuesFieldMissingOnce_RetriesAndSucceeds()
+        {
+            var jira = CreateJiraWithSearchResponses(
+                "{\"isLast\":false}",
+                "{\"issues\":[],\"isLast\":true}");
+            var service = CreateIssueService(jira);
+
+            var result = await service.GetIssuesFromJqlAsync(new IssueSearchOptions("project = TST"), false);
+
+            Assert.Empty(result);
+            jira.RestService.Verify(
+                c => c.ExecuteRequestAsync(Method.POST, "rest/api/3/search/jql", It.IsAny<object>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task GetIssuesFromJqlAsync_IssuesFieldMissingTwice_EmptyLastPage_ReturnsEmptyResult()
+        {
+            var jira = CreateJiraWithSearchResponses("{\"isLast\":true}", "{\"isLast\":true}");
+            var service = CreateIssueService(jira);
+
+            var result = await service.GetIssuesFromJqlAsync(new IssueSearchOptions("project = TST"), false);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetIssuesFromJqlAsync_IssuesFieldMissingTwice_NotLastPage_Throws()
+        {
+            var jira = CreateJiraWithSearchResponses("{\"nextPageToken\":\"token\"}", "{\"nextPageToken\":\"token\"}");
+            var service = CreateIssueService(jira);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.GetIssuesFromJqlAsync(new IssueSearchOptions("project = TST"), false));
+
+            Assert.Contains("'issues'", exception.Message);
+            Assert.Contains("nextPageToken", exception.Message);
+        }
+    }
+}

--- a/Atlassian.Jira.Test/MoqExtensions.cs
+++ b/Atlassian.Jira.Test/MoqExtensions.cs
@@ -17,7 +17,7 @@ namespace Atlassian.Jira.Test
             var pagedResult = new Mock<IPagedQueryResult<Issue>>();
             var issues = remoteIssues.Select(i => i.ToLocal(jira));
             pagedResult.Setup(p => p.GetEnumerator()).Returns(issues.GetEnumerator());
-            mock.Setup(s => s.GetIssuesFromJqlAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            mock.Setup(s => s.GetIssuesFromJqlAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
                 .Returns(Task.FromResult(pagedResult.Object));
         }
 

--- a/Atlassian.Jira/InternalsVisibleTo.cs
+++ b/Atlassian.Jira/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Atlassian.Jira.Test")]

--- a/Atlassian.Jira/Remote/IssueService.cs
+++ b/Atlassian.Jira/Remote/IssueService.cs
@@ -110,21 +110,21 @@ namespace Atlassian.Jira.Remote
                 fields.AddRange(options.AdditionalFields.Select(field => field.Trim().ToLowerInvariant()));
             }
 
-            JToken result;
-            if (isJiraServer)
+            async Task<JToken> ExecuteSearchRequestAsync()
             {
-                var JiraServerParams =  new
+                if (isJiraServer)
                 {
-                    jql = options.Jql,
-                    startAt = options.StartAt,
-                    maxResults = options.MaxIssuesPerRequest ?? this.MaxIssuesPerRequest,
-                    validateQuery = options.ValidateQuery,
-                    fields = fields
-                };
-                result = await _jira.RestClient.ExecuteRequestAsync(Method.POST, "rest/api/2/search", JiraServerParams, token).ConfigureAwait(false);
-            }
-            else
-            {
+                    var JiraServerParams =  new
+                    {
+                        jql = options.Jql,
+                        startAt = options.StartAt,
+                        maxResults = options.MaxIssuesPerRequest ?? this.MaxIssuesPerRequest,
+                        validateQuery = options.ValidateQuery,
+                        fields = fields
+                    };
+                    return await _jira.RestClient.ExecuteRequestAsync(Method.POST, "rest/api/2/search", JiraServerParams, token).ConfigureAwait(false);
+                }
+
                 var parameters = new
                 {
                     jql = options.Jql,
@@ -132,12 +132,37 @@ namespace Atlassian.Jira.Remote
                     fields = fields
 
                 };
-                result = await _jira.RestClient.ExecuteRequestAsync(Method.POST, "rest/api/3/search/jql", parameters, token).ConfigureAwait(false);
+                return await _jira.RestClient.ExecuteRequestAsync(Method.POST, "rest/api/3/search/jql", parameters, token).ConfigureAwait(false);
+            }
 
+            var result = await ExecuteSearchRequestAsync().ConfigureAwait(false);
+            var issuesJson = result["issues"];
+
+            if (issuesJson == null)
+            {
+                // The search endpoint occasionally returns a success response without an 'issues' field;
+                // retry once before deciding how to treat the response.
+                result = await ExecuteSearchRequestAsync().ConfigureAwait(false);
+                issuesJson = result["issues"];
+            }
+
+            if (issuesJson == null)
+            {
+                if (result["isLast"]?.Value<bool>() == true && result["nextPageToken"] == null)
+                {
+                    issuesJson = new JArray();
+                }
+                else
+                {
+                    var responseFields = result is JObject responseObject
+                        ? String.Join(", ", responseObject.Properties().Select(property => property.Name))
+                        : result.Type.ToString();
+                    throw new InvalidOperationException($"Jira search response does not contain an 'issues' field. Response fields: [{responseFields}].");
+                }
             }
 
             var serializerSettings = await this.GetIssueSerializerSettingsAsync(token).ConfigureAwait(false);
-            var issues = result["issues"]
+            var issues = issuesJson
                 .Cast<JObject>()
                 .Select(issueJson =>
                 {


### PR DESCRIPTION
## Problem

`IssueService.GetIssuesFromJqlAsync` dereferences `result["issues"]` unconditionally before enumerating it:

```csharp
var issues = result["issues"]
    .Cast<JObject>()
    ...
```

The Jira Cloud enhanced-search endpoint (`POST /rest/api/3/search/jql`) intermittently returns an **HTTP 200 success body that has no `issues` field**. When that happens, `result["issues"]` is `null` and the `.Cast<JObject>()` throws:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.Enumerable.Cast[TResult](IEnumerable source)
   at Atlassian.Jira.Remote.IssueService...GetIssuesFromJqlAsync(...)
```

This is observed in production across many tenants and all callers that go through JQL search (issue-by-updated-date, issue links, single-issue fetch). The endpoint's normal empty result — `{"issues":[],"isLast":true}` — is well-formed and unaffected; only the field-absent variant triggers the crash. Because every ≥400 status and every error-body is already turned into an exception upstream in `JiraRestClient`, the only way to reach this code with a missing field is a genuine 200.

## Fix

- Extract the request into a local function so it can be issued more than once.
- If `issues` is missing on the first response, **retry once** (the omission is intermittent).
- If it is still missing, treat it as an empty page **only when the body positively says so** (`isLast: true` and no `nextPageToken`); otherwise **throw a descriptive `InvalidOperationException`** listing the response's top-level fields, rather than surfacing an opaque null-reference.

This preserves existing behavior for well-formed responses (no extra request in the common path) and avoids silently dropping results when the response shape is genuinely unexpected.

## Tests

Adds `IssueServiceTest` covering: field present (no retry), field missing once then present (retries and succeeds), field missing twice on an empty final page (returns empty), and field missing twice mid-pagination (throws). Accessing the `internal IssueService` from the test assembly required an `InternalsVisibleTo`.

> **Test-infra note:** the test project targets `netcoreapp3.1` with the xUnit 2.3.1 VS adapter, which cannot execute on a current .NET SDK, and it did **not** compile on `master` due to a pre-existing `CS0854` in `MoqExtensions` (unrelated to this change — the mock setup never accounted for the `isJiraServer` optional parameter added earlier). This PR fixes that compile break, and I verified all four new tests pass locally after temporarily retargeting to `net8.0` and bumping the test adapters. A separate PR to modernize the test toolchain (and add CI) would let these run in the pipeline.
